### PR TITLE
chore(deps): patch form-data and js-yaml vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   "packageManager": "pnpm@10.28.0",
   "pnpm": {
     "overrides": {
-      "uuid": "11.1.1"
+      "uuid": "11.1.1",
+      "form-data@<2.5.6": ">=2.5.6",
+      "js-yaml@<3.15.0": ">=3.15.0 <4"
     }
   },
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,8 @@ catalogs:
 
 overrides:
   uuid: 11.1.1
+  form-data@<2.5.6: '>=2.5.6'
+  js-yaml@<3.15.0: '>=3.15.0 <4'
 
 importers:
 
@@ -974,9 +976,9 @@ packages:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
-  form-data@2.5.5:
-    resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
-    engines: {node: '>= 0.12'}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -1180,8 +1182,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   js-yaml@4.2.0:
@@ -2393,7 +2395,7 @@ snapshots:
       '@types/caseless': 0.12.5
       '@types/node': 25.9.2
       '@types/tough-cookie': 4.0.5
-      form-data: 2.5.5
+      form-data: 4.0.6
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -2723,14 +2725,13 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
-  form-data@2.5.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
       hasown: 2.0.4
       mime-types: 2.1.35
-      safe-buffer: 5.2.1
 
   fs-extra@7.0.1:
     dependencies:
@@ -2957,7 +2958,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -3163,7 +3164,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       pify: 4.0.1
       strip-bom: 3.0.0
 


### PR DESCRIPTION
## Summary

Resolves the two open Dependabot advisories on `main`, both transitive **dev-dependencies**:

| Severity | Package | Advisory | Source |
|----------|---------|----------|--------|
| High | `form-data` `<2.5.6` | CRLF injection via unescaped multipart field names/filenames | `@types/request` (types-only) |
| Moderate | `js-yaml` `<3.15.0` | Quadratic-complexity DoS in merge key handling via repeated aliases | `@changesets/cli` → `read-yaml-file` |

## Approach

Added scoped `pnpm.overrides` that bump **only** the vulnerable ranges:

```jsonc
"form-data@<2.5.6": ">=2.5.6",
"js-yaml@<3.15.0": ">=3.15.0 <4"
```

- `js-yaml` is constrained to the **v3 line** (`>=3.15.0 <4`) because its consumer `read-yaml-file@1.1.0` relies on the v3 `safeLoad` API removed in v4. Resolves to `js-yaml@3.15.0`.
- `form-data` is referenced only by `@types/request` (types-only, never executed at runtime), so letting it resolve to `form-data@4.0.6` is harmless.

Already-safe versions present in the tree (`js-yaml@4.2.0`) are untouched.

## Verification

- `pnpm install --frozen-lockfile` — lockfile valid and consistent
- `pnpm changeset status` — the `js-yaml` consumer toolchain runs cleanly with `3.15.0`
- Vulnerable `form-data@2.5.5` and `js-yaml@3.14.2` no longer appear in `pnpm-lock.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)